### PR TITLE
Build with Vite

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kobweb = "0.15.0"
 kotlin = "1.9.20"
 kotlinx-coroutines = "1.6.0"
 kotlinx-html = "0.7.3"
+vite-kotlin = "0.3.3"
 
 [libraries]
 firebase-kotlin-bindings = { module = "dev.bitspittle:firebase-kotlin-bindings", version.ref = "firebase-bindings" }
@@ -24,3 +25,4 @@ kobweb-application = { id = "com.varabyte.kobweb.application", version.ref = "ko
 kobwebx-markdown = { id = "com.varabyte.kobwebx.markdown", version.ref = "kobweb" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+vite-kotlin = { id = "dev.opensavvy.vite.kotlin", version.ref = "vite-kotlin" }

--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.kobweb.application)
     alias(libs.plugins.kobwebx.markdown)
+    alias(libs.plugins.vite.kotlin)
 }
 
 repositories {
@@ -37,8 +38,11 @@ kobweb {
                 script {
                     // Needed by components/layouts/BlogLayout.kt
                     src = "/highlight.js/highlight.min.js"
+                    type = "module"
                 }
             }
+
+            scriptAttributes.put("type", "module")
         }
     }
 
@@ -203,6 +207,21 @@ kotlin {
                 implementation(libs.kobwebx.markdown)
                 implementation(libs.firebase.kotlin.bindings)
             }
+        }
+    }
+}
+
+// Vite requires the static files (index.html…) to be in the same directory as the JS files.
+// This flattens the 'public' subdirectory when building with Vite.
+for (task in listOf(tasks.viteCompileKotlinDev, tasks.viteCompileKotlinProd)) {
+    task {
+        eachFile {
+            relativePath = RelativePath(
+                /* endsWithFile = */ relativeSourcePath.isFile,
+                *relativeSourcePath.segments
+                    .filter { it != "public" }
+                    .toTypedArray()
+            )
         }
     }
 }


### PR DESCRIPTION
Building the blog with Vite instead of Webpack, using [my Gradle plugin](https://gitlab.com/opensavvy/kotlin-vite).

### Impact

1. Using Webpack, static files are in the `public` directory. Vite needs the `index.html` to be in the working directory. This PR contains a configuration change to flatten the `public` directory. If the Kobweb plugin ever adopts Vite, it could configure this by itself.
2. Vite needs the JS file to be imported with `<script … type="module">`. This is currently not contained in this PR because I'm not sure how to edit that.

Once these two things are fixed,
- `./gradlew :site:viteRun` compiles and hosts the development version,
- `./gradlew :site:viteCompileDev --continuous` enables auto-reload (must be run additionally to the previous command!)
- `./gradlew :site:viteBuild` generates the production bundle in `site/build/vite/dist`.

### Performance

// To be measured

Currently, the plugin attempts to configure as little as possible. Vite is primarily made with ES6 modules in mind—currently, the files are preprocessed by Vite. Since Kotlin recently added ES6 support, in the future the Vite plugin could get even faster. However, [ES6 modules have downsides](https://youtrack.jetbrains.com/issue/KT-8373/JS-support-ES6-as-compilation-target#focus=Comments-27-7356556.0-0), and I'm happy with the current speed.